### PR TITLE
Update the list of members

### DIFF
--- a/en-US.Rmd
+++ b/en-US.Rmd
@@ -105,7 +105,6 @@ This procedure is briefly summarized [here](https://bioconductor.github.io/CodeO
 * Federico Marini fede.maro@gmail.com (until 2024) he/him [EN, IT, DE]
 * Sowmya Parthiban sowmyaparthiban@gmail.com (until 2024) she/her [EN, Tamil]
 * Shixiang Wang wangshx@shanghaitech.edu.cn (until 2025) he/him [CN, EN]
-* Lluís Revilla lluis.revilla@gmail.com (until 2024) he/him [CAT, ES, EN]
 * Kevin Rue-Albrecht kevinrue67@gmail.com  (until 2024) he/him [FR, EN] (CAB)
 * Paulina Boadiwaa Mensah pabbyboadiwaa@gmail.com (until 2025) she/her [EN, Akan]
 * Peace Sandy peacesandy04@gmail.com she/her (until 2025) [EN]


### PR DESCRIPTION
My term finished on December 2024. I'm removing myself from the list. 
I don't know if other have step down and all the new members joined. 
Feel free to use this PR to update the list of members. 

Suggestion: keep the list of members separate from the code of conduct itself. This will make it easier updating the CoC without changing the members of the list. 